### PR TITLE
feat(action): add inputs with env fallbacks

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -26,7 +26,18 @@ Path-specific patterns will be supported in Phase 2.
 
 Create `.github/workflows/pr-commands.yml`:
 
-**Option A: Using GITHUB_TOKEN (simpler, comments from workflow user)**
+Smyklot supports two ways to pass parameters:
+
+- **Inputs** (recommended): Cleaner syntax using action inputs
+- **Environment variables**: Alternative approach, useful for
+  compatibility
+
+Both approaches support automatic fallback to environment variables when
+inputs are not provided.
+
+#### Option A: Using GITHUB_TOKEN (simpler, comments from workflow user)
+
+Using inputs:
 
 ```yaml
 name: PR Commands
@@ -57,7 +68,22 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Run Smyklot
-        uses: bartsmykla/smyklot@feat/go-rewrite-github-app
+        uses: bartsmykla/smyklot@v0.1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          comment-body: ${{ github.event.comment.body }}
+          comment-id: ${{ github.event.comment.id }}
+          pr-number: ${{ github.event.issue.number }}
+          repo-owner: ${{ github.repository_owner }}
+          repo-name: ${{ github.event.repository.name }}
+          comment-author: ${{ github.event.comment.user.login }}
+```
+
+Using environment variables:
+
+```yaml
+      - name: Run Smyklot
+        uses: bartsmykla/smyklot@v0.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMENT_BODY: ${{ github.event.comment.body }}
@@ -68,7 +94,9 @@ jobs:
           COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
 ```
 
-**Option B: Using GitHub App (recommended, comments from app)**
+#### Option B: Using GitHub App (recommended, comments from app)
+
+Using inputs:
 
 ```yaml
 name: PR Commands
@@ -106,7 +134,22 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Run Smyklot
-        uses: bartsmykla/smyklot@feat/go-rewrite-github-app
+        uses: bartsmykla/smyklot@v0.1.0
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          comment-body: ${{ github.event.comment.body }}
+          comment-id: ${{ github.event.comment.id }}
+          pr-number: ${{ github.event.issue.number }}
+          repo-owner: ${{ github.repository_owner }}
+          repo-name: ${{ github.event.repository.name }}
+          comment-author: ${{ github.event.comment.user.login }}
+```
+
+Using environment variables:
+
+```yaml
+      - name: Run Smyklot
+        uses: bartsmykla/smyklot@v0.1.0
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           COMMENT_BODY: ${{ github.event.comment.body }}

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,36 @@ branding:
   icon: check-circle
   color: green
 
+inputs:
+  token:
+    description: GitHub token for API authentication
+    required: false
+    default: ''
+  comment-body:
+    description: PR comment body text
+    required: false
+    default: ''
+  comment-id:
+    description: PR comment ID
+    required: false
+    default: ''
+  pr-number:
+    description: Pull request number
+    required: false
+    default: ''
+  repo-owner:
+    description: Repository owner
+    required: false
+    default: ''
+  repo-name:
+    description: Repository name
+    required: false
+    default: ''
+  comment-author:
+    description: Comment author username
+    required: false
+    default: ''
+
 runs:
   using: composite
   steps:
@@ -23,4 +53,12 @@ runs:
 
     - name: Execute command
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.token || env.GITHUB_TOKEN }}
+        COMMENT_BODY: ${{ inputs.comment-body || env.COMMENT_BODY }}
+        COMMENT_ID: ${{ inputs.comment-id || env.COMMENT_ID }}
+        PR_NUMBER: ${{ inputs.pr-number || env.PR_NUMBER }}
+        REPO_OWNER: ${{ inputs.repo-owner || env.REPO_OWNER }}
+        REPO_NAME: ${{ inputs.repo-name || env.REPO_NAME }}
+        COMMENT_AUTHOR: ${{ inputs.comment-author || env.COMMENT_AUTHOR }}
       run: ${{ runner.temp }}/smyklot-github-action


### PR DESCRIPTION
## Summary

Add action inputs to support both input-based and environment variable-based parameter passing. All inputs are optional with automatic fallback to environment variables when not provided.

## Changes

- Add 7 action inputs (`token`, `comment-body`, `comment-id`, `pr-number`, `repo-owner`, `repo-name`, `comment-author`)
- Use fallback pattern: `${{ inputs.X || env.X }}`
- Update `DEPLOYMENT.md` with examples of both input and env var approaches
- Convert Option A/B sections to proper markdown headings

## Benefits

- Cleaner workflow syntax using `with:` instead of `env:`
- Maintains backward compatibility with environment variables
- Users can choose their preferred approach
- Automatic fallback ensures flexibility

## Example Usage

**Using inputs (recommended):**

```yaml
- name: Run Smyklot
  uses: bartsmykla/smyklot@v0.2.0
  with:
    token: ${{ steps.generate-token.outputs.token }}
    comment-body: ${{ github.event.comment.body }}
    # ... other inputs
```

**Using environment variables (still supported):**

```yaml
- name: Run Smyklot
  uses: bartsmykla/smyklot@v0.2.0
  env:
    GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
    COMMENT_BODY: ${{ github.event.comment.body }}
    # ... other env vars
```

## Testing

- Linting passes
- Compatible with existing workflows
- Tested locally with both approaches