### PR TITLE
feat(commands): add merge after CI modifier

### DIFF
--- a/cmd/github-action/main_suite_test.go
+++ b/cmd/github-action/main_suite_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMain(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Main Suite")
+}

--- a/cmd/github-action/main_test.go
+++ b/cmd/github-action/main_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/bartsmykla/smyklot/pkg/github"
+)
+
+var _ = Describe("Main Pending CI Functions [Unit]", func() {
+	Describe("getPendingCILabel", func() {
+		It("should return merge label for merge method", func() {
+			label := getPendingCILabel(github.MergeMethodMerge)
+			Expect(label).To(Equal(github.LabelPendingCIMerge))
+		})
+
+		It("should return squash label for squash method", func() {
+			label := getPendingCILabel(github.MergeMethodSquash)
+			Expect(label).To(Equal(github.LabelPendingCISquash))
+		})
+
+		It("should return rebase label for rebase method", func() {
+			label := getPendingCILabel(github.MergeMethodRebase)
+			Expect(label).To(Equal(github.LabelPendingCIRebase))
+		})
+
+		It("should return merge label for unknown method", func() {
+			label := getPendingCILabel(github.MergeMethod("unknown"))
+			Expect(label).To(Equal(github.LabelPendingCIMerge))
+		})
+	})
+
+	Describe("getMergeMethodName", func() {
+		It("should return 'merge' for merge method", func() {
+			name := getMergeMethodName(github.MergeMethodMerge)
+			Expect(name).To(Equal("merge"))
+		})
+
+		It("should return 'squash' for squash method", func() {
+			name := getMergeMethodName(github.MergeMethodSquash)
+			Expect(name).To(Equal("squash"))
+		})
+
+		It("should return 'rebase' for rebase method", func() {
+			name := getMergeMethodName(github.MergeMethodRebase)
+			Expect(name).To(Equal("rebase"))
+		})
+
+		It("should return 'merge' for unknown method", func() {
+			name := getMergeMethodName(github.MergeMethod("unknown"))
+			Expect(name).To(Equal("merge"))
+		})
+	})
+
+	Describe("isBotAlreadyApproved", func() {
+		It("should return true when bot has approved", func() {
+			info := &github.PRInfo{
+				ApprovedBy: []string{"user1", "smyklot[bot]", "user2"},
+			}
+			Expect(isBotAlreadyApproved(info, "smyklot[bot]")).To(BeTrue())
+		})
+
+		It("should return false when bot has not approved", func() {
+			info := &github.PRInfo{
+				ApprovedBy: []string{"user1", "user2"},
+			}
+			Expect(isBotAlreadyApproved(info, "smyklot[bot]")).To(BeFalse())
+		})
+
+		It("should return false for empty approvers list", func() {
+			info := &github.PRInfo{
+				ApprovedBy: []string{},
+			}
+			Expect(isBotAlreadyApproved(info, "smyklot[bot]")).To(BeFalse())
+		})
+
+		It("should handle different bot usernames", func() {
+			info := &github.PRInfo{
+				ApprovedBy: []string{"custom-bot"},
+			}
+			Expect(isBotAlreadyApproved(info, "custom-bot")).To(BeTrue())
+			Expect(isBotAlreadyApproved(info, "smyklot[bot]")).To(BeFalse())
+		})
+	})
+
+	Describe("shouldEnableAutoMerge", func() {
+		It("should return true for merge queue error", func() {
+			err := NewGitHubError(ErrMergePR, githubError("merge queue is required"))
+			Expect(shouldEnableAutoMerge(err)).To(BeTrue())
+		})
+
+		It("should return true for status checks error", func() {
+			err := NewGitHubError(ErrMergePR, githubError("required status check"))
+			Expect(shouldEnableAutoMerge(err)).To(BeTrue())
+		})
+
+		It("should return true for branch protection error", func() {
+			err := NewGitHubError(ErrMergePR, githubError("branch protection rules"))
+			Expect(shouldEnableAutoMerge(err)).To(BeTrue())
+		})
+
+		It("should return false for other errors", func() {
+			err := NewGitHubError(ErrMergePR, githubError("some other error"))
+			Expect(shouldEnableAutoMerge(err)).To(BeFalse())
+		})
+	})
+})
+
+// githubError is a simple error type for testing
+type githubError string
+
+func (e githubError) Error() string {
+	return string(e)
+}

--- a/cmd/github-action/poll_test.go
+++ b/cmd/github-action/poll_test.go
@@ -1,0 +1,489 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/bartsmykla/smyklot/pkg/config"
+	"github.com/bartsmykla/smyklot/pkg/github"
+)
+
+var _ = Describe("Poll Pending CI [Unit]", func() {
+	Describe("parsePendingCILabel", func() {
+		It("should parse smyklot:pending-ci label as merge method", func() {
+			method, label := parsePendingCILabel(github.LabelPendingCIMerge)
+			Expect(method).To(Equal(github.MergeMethodMerge))
+			Expect(label).To(Equal(github.LabelPendingCIMerge))
+		})
+
+		It("should parse smyklot:pending-ci:squash label as squash method", func() {
+			method, label := parsePendingCILabel(github.LabelPendingCISquash)
+			Expect(method).To(Equal(github.MergeMethodSquash))
+			Expect(label).To(Equal(github.LabelPendingCISquash))
+		})
+
+		It("should parse smyklot:pending-ci:rebase label as rebase method", func() {
+			method, label := parsePendingCILabel(github.LabelPendingCIRebase)
+			Expect(method).To(Equal(github.MergeMethodRebase))
+			Expect(label).To(Equal(github.LabelPendingCIRebase))
+		})
+
+		It("should return empty string for non-pending-ci labels", func() {
+			method, label := parsePendingCILabel("some-other-label")
+			Expect(method).To(Equal(github.MergeMethod("")))
+			Expect(label).To(BeEmpty())
+		})
+
+		It("should return empty string for reaction labels", func() {
+			method, label := parsePendingCILabel(github.LabelReactionApprove)
+			Expect(method).To(Equal(github.MergeMethod("")))
+			Expect(label).To(BeEmpty())
+		})
+	})
+
+	Describe("filterPendingCIPRs", func() {
+		It("should filter PRs with pending-ci merge label", func() {
+			prs := []map[string]interface{}{
+				{
+					"number": float64(1),
+					"labels": []interface{}{
+						map[string]interface{}{"name": github.LabelPendingCIMerge},
+					},
+				},
+				{
+					"number": float64(2),
+					"labels": []interface{}{
+						map[string]interface{}{"name": "other-label"},
+					},
+				},
+			}
+
+			result := filterPendingCIPRs(prs)
+			Expect(result).To(HaveLen(1))
+			Expect(extractPRNumber(result[0].prData)).To(Equal(1))
+			Expect(result[0].method).To(Equal(github.MergeMethodMerge))
+			Expect(result[0].label).To(Equal(github.LabelPendingCIMerge))
+		})
+
+		It("should filter PRs with pending-ci squash label", func() {
+			prs := []map[string]interface{}{
+				{
+					"number": float64(1),
+					"labels": []interface{}{
+						map[string]interface{}{"name": github.LabelPendingCISquash},
+					},
+				},
+			}
+
+			result := filterPendingCIPRs(prs)
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].method).To(Equal(github.MergeMethodSquash))
+		})
+
+		It("should filter PRs with pending-ci rebase label", func() {
+			prs := []map[string]interface{}{
+				{
+					"number": float64(1),
+					"labels": []interface{}{
+						map[string]interface{}{"name": github.LabelPendingCIRebase},
+					},
+				},
+			}
+
+			result := filterPendingCIPRs(prs)
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].method).To(Equal(github.MergeMethodRebase))
+		})
+
+		It("should return empty slice when no PRs have pending-ci labels", func() {
+			prs := []map[string]interface{}{
+				{
+					"number": float64(1),
+					"labels": []interface{}{
+						map[string]interface{}{"name": "other-label"},
+					},
+				},
+			}
+
+			result := filterPendingCIPRs(prs)
+			Expect(result).To(BeEmpty())
+		})
+
+		It("should handle PRs without labels field", func() {
+			prs := []map[string]interface{}{
+				{
+					"number": float64(1),
+				},
+			}
+
+			result := filterPendingCIPRs(prs)
+			Expect(result).To(BeEmpty())
+		})
+
+		It("should handle PRs with empty labels array", func() {
+			prs := []map[string]interface{}{
+				{
+					"number": float64(1),
+					"labels": []interface{}{},
+				},
+			}
+
+			result := filterPendingCIPRs(prs)
+			Expect(result).To(BeEmpty())
+		})
+
+		It("should only pick first pending-ci label per PR", func() {
+			prs := []map[string]interface{}{
+				{
+					"number": float64(1),
+					"labels": []interface{}{
+						map[string]interface{}{"name": github.LabelPendingCIMerge},
+						map[string]interface{}{"name": github.LabelPendingCISquash},
+					},
+				},
+			}
+
+			result := filterPendingCIPRs(prs)
+			Expect(result).To(HaveLen(1))
+			// First label wins
+			Expect(result[0].method).To(Equal(github.MergeMethodMerge))
+		})
+
+		It("should filter multiple PRs with different pending-ci labels", func() {
+			prs := []map[string]interface{}{
+				{
+					"number": float64(1),
+					"labels": []interface{}{
+						map[string]interface{}{"name": github.LabelPendingCIMerge},
+					},
+				},
+				{
+					"number": float64(2),
+					"labels": []interface{}{
+						map[string]interface{}{"name": github.LabelPendingCISquash},
+					},
+				},
+				{
+					"number": float64(3),
+					"labels": []interface{}{
+						map[string]interface{}{"name": "other-label"},
+					},
+				},
+			}
+
+			result := filterPendingCIPRs(prs)
+			Expect(result).To(HaveLen(2))
+		})
+	})
+
+	Describe("extractPRNumber", func() {
+		It("should extract PR number from PR data", func() {
+			pr := map[string]interface{}{
+				"number": float64(42),
+			}
+			Expect(extractPRNumber(pr)).To(Equal(42))
+		})
+
+		It("should return 0 for missing number field", func() {
+			pr := map[string]interface{}{}
+			Expect(extractPRNumber(pr)).To(Equal(0))
+		})
+
+		It("should return 0 for invalid number type", func() {
+			pr := map[string]interface{}{
+				"number": "not-a-number",
+			}
+			Expect(extractPRNumber(pr)).To(Equal(0))
+		})
+	})
+
+	Describe("processPendingCIPR", func() {
+		var server *httptest.Server
+
+		AfterEach(func() {
+			if server != nil {
+				server.Close()
+			}
+		})
+
+		Context("when CI is passing", func() {
+			It("should merge the PR and remove label", func() {
+				mergeRequested := false
+				labelRemoved := false
+				commentPosted := false
+
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch {
+					case r.URL.Path == "/repos/owner/repo/pulls/42" && r.Method == "GET":
+						w.WriteHeader(http.StatusOK)
+						_ = json.NewEncoder(w).Encode(map[string]interface{}{
+							"head": map[string]interface{}{
+								"sha": "abc123",
+							},
+						})
+
+					case r.URL.Path == "/repos/owner/repo/commits/abc123/check-runs" && r.Method == "GET":
+						w.WriteHeader(http.StatusOK)
+						_ = json.NewEncoder(w).Encode(map[string]interface{}{
+							"total_count": 2,
+							"check_runs": []map[string]interface{}{
+								{"status": "completed", "conclusion": "success"},
+								{"status": "completed", "conclusion": "success"},
+							},
+						})
+
+					case r.URL.Path == "/repos/owner/repo/pulls/42/merge" && r.Method == "PUT":
+						mergeRequested = true
+						w.WriteHeader(http.StatusOK)
+						_ = json.NewEncoder(w).Encode(map[string]interface{}{
+							"merged": true,
+						})
+
+					case r.URL.Path == "/repos/owner/repo/issues/42/labels/smyklot:pending-ci" && r.Method == "DELETE":
+						labelRemoved = true
+						w.WriteHeader(http.StatusOK)
+
+					case r.URL.Path == "/repos/owner/repo/issues/42/comments" && r.Method == "POST":
+						commentPosted = true
+						w.WriteHeader(http.StatusCreated)
+						_ = json.NewEncoder(w).Encode(map[string]interface{}{
+							"id": 1,
+						})
+
+					default:
+						w.WriteHeader(http.StatusNotFound)
+					}
+				}))
+
+				client, err := github.NewClient("test-token", server.URL)
+				Expect(err).NotTo(HaveOccurred())
+
+				bc := config.Default()
+				pr := pendingCIPR{
+					prData: map[string]interface{}{"number": float64(42)},
+					method: github.MergeMethodMerge,
+					label:  github.LabelPendingCIMerge,
+				}
+
+				err = processPendingCIPR(context.Background(), client, bc, "owner", "repo", pr)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(mergeRequested).To(BeTrue())
+				Expect(labelRemoved).To(BeTrue())
+				Expect(commentPosted).To(BeTrue())
+			})
+		})
+
+		Context("when CI is failing", func() {
+			It("should remove label and post failure comment", func() {
+				labelRemoved := false
+				commentPosted := false
+				var postedComment string
+
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch {
+					case r.URL.Path == "/repos/owner/repo/pulls/42" && r.Method == "GET":
+						w.WriteHeader(http.StatusOK)
+						_ = json.NewEncoder(w).Encode(map[string]interface{}{
+							"head": map[string]interface{}{
+								"sha": "abc123",
+							},
+						})
+
+					case r.URL.Path == "/repos/owner/repo/commits/abc123/check-runs" && r.Method == "GET":
+						w.WriteHeader(http.StatusOK)
+						_ = json.NewEncoder(w).Encode(map[string]interface{}{
+							"total_count": 2,
+							"check_runs": []map[string]interface{}{
+								{"status": "completed", "conclusion": "success"},
+								{"status": "completed", "conclusion": "failure"},
+							},
+						})
+
+					case r.URL.Path == "/repos/owner/repo/issues/42/labels/smyklot:pending-ci" && r.Method == "DELETE":
+						labelRemoved = true
+						w.WriteHeader(http.StatusOK)
+
+					case r.URL.Path == "/repos/owner/repo/issues/42/comments" && r.Method == "POST":
+						commentPosted = true
+						var body map[string]string
+						_ = json.NewDecoder(r.Body).Decode(&body)
+						postedComment = body["body"]
+						w.WriteHeader(http.StatusCreated)
+						_ = json.NewEncoder(w).Encode(map[string]interface{}{
+							"id": 1,
+						})
+
+					default:
+						w.WriteHeader(http.StatusNotFound)
+					}
+				}))
+
+				client, err := github.NewClient("test-token", server.URL)
+				Expect(err).NotTo(HaveOccurred())
+
+				bc := config.Default()
+				pr := pendingCIPR{
+					prData: map[string]interface{}{"number": float64(42)},
+					method: github.MergeMethodMerge,
+					label:  github.LabelPendingCIMerge,
+				}
+
+				err = processPendingCIPR(context.Background(), client, bc, "owner", "repo", pr)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(labelRemoved).To(BeTrue())
+				Expect(commentPosted).To(BeTrue())
+				Expect(postedComment).To(ContainSubstring("CI Failed"))
+			})
+		})
+
+		Context("when CI is still pending", func() {
+			It("should not merge or remove label", func() {
+				mergeRequested := false
+				labelRemoved := false
+
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch {
+					case r.URL.Path == "/repos/owner/repo/pulls/42" && r.Method == "GET":
+						w.WriteHeader(http.StatusOK)
+						_ = json.NewEncoder(w).Encode(map[string]interface{}{
+							"head": map[string]interface{}{
+								"sha": "abc123",
+							},
+						})
+
+					case r.URL.Path == "/repos/owner/repo/commits/abc123/check-runs" && r.Method == "GET":
+						w.WriteHeader(http.StatusOK)
+						_ = json.NewEncoder(w).Encode(map[string]interface{}{
+							"total_count": 2,
+							"check_runs": []map[string]interface{}{
+								{"status": "completed", "conclusion": "success"},
+								{"status": "in_progress", "conclusion": nil},
+							},
+						})
+
+					case r.URL.Path == "/repos/owner/repo/pulls/42/merge" && r.Method == "PUT":
+						mergeRequested = true
+						w.WriteHeader(http.StatusOK)
+
+					case r.URL.Path == "/repos/owner/repo/issues/42/labels/smyklot:pending-ci" && r.Method == "DELETE":
+						labelRemoved = true
+						w.WriteHeader(http.StatusOK)
+
+					default:
+						w.WriteHeader(http.StatusNotFound)
+					}
+				}))
+
+				client, err := github.NewClient("test-token", server.URL)
+				Expect(err).NotTo(HaveOccurred())
+
+				bc := config.Default()
+				pr := pendingCIPR{
+					prData: map[string]interface{}{"number": float64(42)},
+					method: github.MergeMethodMerge,
+					label:  github.LabelPendingCIMerge,
+				}
+
+				err = processPendingCIPR(context.Background(), client, bc, "owner", "repo", pr)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(mergeRequested).To(BeFalse())
+				Expect(labelRemoved).To(BeFalse())
+			})
+		})
+
+		Context("when squash merge is requested", func() {
+			It("should use squash merge method", func() {
+				var mergeMethod string
+
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch {
+					case r.URL.Path == "/repos/owner/repo/pulls/42" && r.Method == "GET":
+						w.WriteHeader(http.StatusOK)
+						_ = json.NewEncoder(w).Encode(map[string]interface{}{
+							"head": map[string]interface{}{
+								"sha": "abc123",
+							},
+						})
+
+					case r.URL.Path == "/repos/owner/repo/commits/abc123/check-runs" && r.Method == "GET":
+						w.WriteHeader(http.StatusOK)
+						_ = json.NewEncoder(w).Encode(map[string]interface{}{
+							"total_count": 1,
+							"check_runs": []map[string]interface{}{
+								{"status": "completed", "conclusion": "success"},
+							},
+						})
+
+					case r.URL.Path == "/repos/owner/repo/pulls/42/merge" && r.Method == "PUT":
+						var body map[string]interface{}
+						_ = json.NewDecoder(r.Body).Decode(&body)
+						mergeMethod = body["merge_method"].(string)
+						w.WriteHeader(http.StatusOK)
+						_ = json.NewEncoder(w).Encode(map[string]interface{}{
+							"merged": true,
+						})
+
+					case r.URL.Path == "/repos/owner/repo/issues/42/labels/smyklot:pending-ci:squash" && r.Method == "DELETE":
+						w.WriteHeader(http.StatusOK)
+
+					case r.URL.Path == "/repos/owner/repo/issues/42/comments" && r.Method == "POST":
+						w.WriteHeader(http.StatusCreated)
+						_ = json.NewEncoder(w).Encode(map[string]interface{}{
+							"id": 1,
+						})
+
+					default:
+						w.WriteHeader(http.StatusNotFound)
+					}
+				}))
+
+				client, err := github.NewClient("test-token", server.URL)
+				Expect(err).NotTo(HaveOccurred())
+
+				bc := config.Default()
+				pr := pendingCIPR{
+					prData: map[string]interface{}{"number": float64(42)},
+					method: github.MergeMethodSquash,
+					label:  github.LabelPendingCISquash,
+				}
+
+				err = processPendingCIPR(context.Background(), client, bc, "owner", "repo", pr)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(mergeMethod).To(Equal("squash"))
+			})
+		})
+	})
+
+	Describe("processPendingCIPRs", func() {
+		var server *httptest.Server
+
+		AfterEach(func() {
+			if server != nil {
+				server.Close()
+			}
+		})
+
+		It("should return nil when no PRs have pending-ci labels", func() {
+			prs := []map[string]interface{}{
+				{
+					"number": float64(1),
+					"labels": []interface{}{
+						map[string]interface{}{"name": "other-label"},
+					},
+				},
+			}
+
+			client, err := github.NewClient("test-token", "http://localhost")
+			Expect(err).NotTo(HaveOccurred())
+
+			bc := config.Default()
+			err = processPendingCIPRs(context.Background(), client, bc, "owner", "repo", prs)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/pkg/commands/parser_test.go
+++ b/pkg/commands/parser_test.go
@@ -782,5 +782,382 @@ All changes tested:
 				Expect(cmd.IsValid).To(BeFalse())
 			})
 		})
+
+		Context("when parsing 'after CI' modifier with merge commands", func() {
+			// Basic slash command variations
+			It("should parse '/merge after CI' with WaitForCI=true", func() {
+				cmd, err := commands.ParseCommand("/merge after CI", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.Type).To(Equal(commands.CommandMerge))
+				Expect(cmd.WaitForCI).To(BeTrue())
+				Expect(cmd.IsValid).To(BeTrue())
+			})
+
+			It("should parse '/squash after CI' with WaitForCI=true", func() {
+				cmd, err := commands.ParseCommand("/squash after CI", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.Type).To(Equal(commands.CommandSquash))
+				Expect(cmd.WaitForCI).To(BeTrue())
+				Expect(cmd.IsValid).To(BeTrue())
+			})
+
+			It("should parse '/rebase after CI' with WaitForCI=true", func() {
+				cmd, err := commands.ParseCommand("/rebase after CI", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.Type).To(Equal(commands.CommandRebase))
+				Expect(cmd.WaitForCI).To(BeTrue())
+				Expect(cmd.IsValid).To(BeTrue())
+			})
+
+			// Case insensitivity
+			It("should be case-insensitive for 'after ci'", func() {
+				cmd, err := commands.ParseCommand("/merge after ci", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			It("should be case-insensitive for 'AFTER CI'", func() {
+				cmd, err := commands.ParseCommand("/merge AFTER CI", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			It("should be case-insensitive for 'After Ci'", func() {
+				cmd, err := commands.ParseCommand("/merge After Ci", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			// "when green" variations
+			It("should parse '/merge when green'", func() {
+				cmd, err := commands.ParseCommand("/merge when green", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.Type).To(Equal(commands.CommandMerge))
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			It("should parse '/squash when green'", func() {
+				cmd, err := commands.ParseCommand("/squash when green", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.Type).To(Equal(commands.CommandSquash))
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			// "when checks pass" variations
+			It("should parse '/merge when checks pass'", func() {
+				cmd, err := commands.ParseCommand("/merge when checks pass", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.Type).To(Equal(commands.CommandMerge))
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			It("should parse '/merge when check passes'", func() {
+				cmd, err := commands.ParseCommand("/merge when check passes", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			// "once CI passes" variations
+			It("should parse '/merge once CI passes'", func() {
+				cmd, err := commands.ParseCommand("/merge once CI passes", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.Type).To(Equal(commands.CommandMerge))
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			It("should parse '/merge once checks pass'", func() {
+				cmd, err := commands.ParseCommand("/merge once checks pass", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			// "after checks" variations
+			It("should parse '/merge after checks'", func() {
+				cmd, err := commands.ParseCommand("/merge after checks", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.Type).To(Equal(commands.CommandMerge))
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			It("should parse '/merge after check'", func() {
+				cmd, err := commands.ParseCommand("/merge after check", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			// "when CI passes" variation
+			It("should parse '/merge when CI passes'", func() {
+				cmd, err := commands.ParseCommand("/merge when CI passes", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			// "checks are green" variation
+			It("should parse '/merge when checks are green'", func() {
+				cmd, err := commands.ParseCommand("/merge when checks are green", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			// Mention command variations
+			It("should parse '@smyklot merge after CI'", func() {
+				cmd, err := commands.ParseCommand("@smyklot merge after CI", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.Type).To(Equal(commands.CommandMerge))
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			It("should parse '@smyklot squash when green'", func() {
+				cmd, err := commands.ParseCommand("@smyklot squash when green", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.Type).To(Equal(commands.CommandSquash))
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			// Bare command variations
+			// Note: Bare commands with "after CI" modifier contain natural language
+			// words like "after", "when", "once" which trigger the natural language
+			// detection filter. This is expected behavior - users should use slash
+			// or mention commands for the modifier syntax.
+			It("should NOT parse 'merge after CI' as bare command due to natural language detection", func() {
+				cmd, err := commands.ParseCommand("merge after CI", nil)
+				Expect(err).NotTo(HaveOccurred())
+				// "after" is a natural language indicator, so bare command parsing is skipped
+				Expect(cmd.IsValid).To(BeFalse())
+			})
+
+			It("should NOT parse 'squash when green' as bare command due to natural language detection", func() {
+				cmd, err := commands.ParseCommand("squash when green", nil)
+				Expect(err).NotTo(HaveOccurred())
+				// "when" is a natural language indicator, so bare command parsing is skipped
+				Expect(cmd.IsValid).To(BeFalse())
+			})
+
+			// Combined commands
+			It("should parse '/approve /merge after CI' with approve first", func() {
+				cmd, err := commands.ParseCommand("/approve /merge after CI", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.Commands).To(HaveLen(2))
+				Expect(cmd.Commands[0]).To(Equal(commands.CommandApprove))
+				Expect(cmd.Commands[1]).To(Equal(commands.CommandMerge))
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			It("should NOT parse 'lgtm merge after CI' as bare command due to natural language detection", func() {
+				cmd, err := commands.ParseCommand("lgtm merge after CI", nil)
+				Expect(err).NotTo(HaveOccurred())
+				// "after" is a natural language indicator, so bare command parsing is skipped
+				Expect(cmd.IsValid).To(BeFalse())
+			})
+
+			// Multiline
+			It("should parse modifier in multiline comment", func() {
+				cmd, err := commands.ParseCommand("/merge\nafter CI please", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.Type).To(Equal(commands.CommandMerge))
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			It("should parse modifier when on separate line", func() {
+				comment := `/merge
+when checks pass`
+				cmd, err := commands.ParseCommand(comment, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+		})
+
+		Context("when 'after CI' modifier should NOT apply", func() {
+			// Regular merge without modifier
+			It("should NOT set WaitForCI for plain '/merge'", func() {
+				cmd, err := commands.ParseCommand("/merge", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.Type).To(Equal(commands.CommandMerge))
+				Expect(cmd.WaitForCI).To(BeFalse())
+			})
+
+			// Approve-only commands should not get WaitForCI
+			It("should NOT set WaitForCI for '/approve' even with modifier text", func() {
+				cmd, err := commands.ParseCommand("/approve after CI", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.Type).To(Equal(commands.CommandApprove))
+				Expect(cmd.WaitForCI).To(BeFalse())
+			})
+
+			It("should NOT set WaitForCI for 'lgtm' alone", func() {
+				cmd, err := commands.ParseCommand("lgtm", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.WaitForCI).To(BeFalse())
+			})
+
+			// Non-command text with CI-related words
+			It("should NOT parse as command: 'waiting for CI to pass'", func() {
+				cmd, err := commands.ParseCommand("waiting for CI to pass", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.IsValid).To(BeFalse())
+			})
+
+			It("should NOT parse natural text mentioning CI", func() {
+				cmd, err := commands.ParseCommand("Let's merge this after CI is done", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.IsValid).To(BeFalse())
+			})
+
+			It("should NOT match partial phrases like 'after breakfast'", func() {
+				cmd, err := commands.ParseCommand("/merge after breakfast", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.Type).To(Equal(commands.CommandMerge))
+				Expect(cmd.WaitForCI).To(BeFalse())
+			})
+
+			It("should NOT match 'after lunch'", func() {
+				cmd, err := commands.ParseCommand("/merge after lunch", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.WaitForCI).To(BeFalse())
+			})
+
+			It("should NOT match 'when ready'", func() {
+				cmd, err := commands.ParseCommand("/merge when ready", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.WaitForCI).To(BeFalse())
+			})
+
+			// Cleanup command should not get WaitForCI
+			It("should NOT set WaitForCI for '/cleanup'", func() {
+				cmd, err := commands.ParseCommand("/cleanup after CI", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.Type).To(Equal(commands.CommandCleanup))
+				Expect(cmd.WaitForCI).To(BeFalse())
+			})
+
+			// Help command should not get WaitForCI
+			It("should NOT set WaitForCI for '/help'", func() {
+				cmd, err := commands.ParseCommand("/help after CI", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.Type).To(Equal(commands.CommandHelp))
+				Expect(cmd.WaitForCI).To(BeFalse())
+			})
+
+			// Unapprove should not get WaitForCI
+			It("should NOT set WaitForCI for '/unapprove'", func() {
+				cmd, err := commands.ParseCommand("/unapprove after CI", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.Type).To(Equal(commands.CommandUnapprove))
+				Expect(cmd.WaitForCI).To(BeFalse())
+			})
+		})
+
+		Context("edge cases for 'after CI' regex matching", func() {
+			// Word boundary tests
+			It("should NOT match 'CIrcle' as CI", func() {
+				cmd, err := commands.ParseCommand("/merge after CIrcle", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.WaitForCI).To(BeFalse())
+			})
+
+			It("should NOT match 'checking' as check", func() {
+				cmd, err := commands.ParseCommand("/merge after checking", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.WaitForCI).To(BeFalse())
+			})
+
+			It("should NOT match 'greenhouse' as green", func() {
+				cmd, err := commands.ParseCommand("/merge when greenhouse", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.WaitForCI).To(BeFalse())
+			})
+
+			// Whitespace variations
+			It("should handle multiple spaces between words", func() {
+				cmd, err := commands.ParseCommand("/merge after   CI", nil)
+				Expect(err).NotTo(HaveOccurred())
+				// \s+ matches one or more whitespace characters, so multiple spaces work
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			It("should handle tabs between words", func() {
+				cmd, err := commands.ParseCommand("/merge after\tCI", nil)
+				Expect(err).NotTo(HaveOccurred())
+				// Tab is whitespace, should match
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			// Extra text around modifier
+			It("should match with text before modifier", func() {
+				cmd, err := commands.ParseCommand("/merge please after CI thanks", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			It("should match with text after modifier", func() {
+				cmd, err := commands.ParseCommand("/merge after CI please", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			// Punctuation
+			It("should match modifier followed by period", func() {
+				cmd, err := commands.ParseCommand("/merge after CI.", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			It("should match modifier followed by exclamation", func() {
+				cmd, err := commands.ParseCommand("/merge after CI!", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			// All variations of pass/passes
+			It("should match 'CI pass'", func() {
+				cmd, err := commands.ParseCommand("/merge when CI pass", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			It("should match 'CI passes'", func() {
+				cmd, err := commands.ParseCommand("/merge when CI passes", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			It("should match 'check pass'", func() {
+				cmd, err := commands.ParseCommand("/merge when check pass", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			It("should match 'checks passes'", func() {
+				cmd, err := commands.ParseCommand("/merge when checks passes", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			// "a green" vs "are green"
+			It("should match 'checks a green'", func() {
+				cmd, err := commands.ParseCommand("/merge when checks a green", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			It("should match 'checks are green'", func() {
+				cmd, err := commands.ParseCommand("/merge when checks are green", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			// After with just the keyword
+			It("should match 'after green'", func() {
+				cmd, err := commands.ParseCommand("/merge after green", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+
+			It("should match 'once green'", func() {
+				cmd, err := commands.ParseCommand("/merge once green", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd.WaitForCI).To(BeTrue())
+			})
+		})
 	})
 })

--- a/pkg/commands/types.go
+++ b/pkg/commands/types.go
@@ -47,4 +47,8 @@ type Command struct {
 
 	// Error contains any parsing error message
 	Error string
+
+	// WaitForCI indicates merge should be deferred until CI passes
+	// Set when "after CI", "when green", "when checks pass" modifier is detected
+	WaitForCI bool
 }

--- a/pkg/feedback/feedback.go
+++ b/pkg/feedback/feedback.go
@@ -445,6 +445,65 @@ func NewReactionMergeRemoved() *Feedback {
 	}
 }
 
+// NewPendingCI creates pending feedback for when merge is waiting for CI
+//
+// The message indicates who triggered the merge and what merge method will be used
+func NewPendingCI(author string, method string) *Feedback {
+	message := fmt.Sprintf(
+		"⏳ **Waiting for CI**\n\n"+
+			"Merge requested by `%s`. Will %s when all checks pass.\n\n"+
+			"The PR will be merged automatically once CI succeeds.",
+		author,
+		method,
+	)
+
+	return &Feedback{
+		Type:    Pending,
+		Emoji:   "⏳",
+		Message: message,
+	}
+}
+
+// NewPendingCIMerged creates success feedback for when a pending-ci merge completes
+//
+// The message indicates that CI passed and the PR was merged
+func NewPendingCIMerged(author string, quietSuccess bool) *Feedback {
+	message := ""
+
+	if !quietSuccess {
+		message = fmt.Sprintf(
+			"✅ **CI Passed - PR Merged**\n\n"+
+				"All checks passed! PR has been merged as requested by `%s`.",
+			author,
+		)
+	}
+
+	return &Feedback{
+		Type:    Success,
+		Emoji:   "✅",
+		Message: message,
+	}
+}
+
+// NewPendingCIFailed creates error feedback for when pending-ci merge is cancelled due to CI failure
+//
+// The reason parameter should describe why CI failed or what checks failed
+func NewPendingCIFailed(reason string) *Feedback {
+	message := fmt.Sprintf(
+		"❌ **CI Failed - Merge Cancelled**\n\n"+
+			"The pending merge has been cancelled because CI checks failed.\n\n"+
+			"**Reason:** %s\n\n"+
+			"Please fix the failing checks and try again.",
+		reason,
+	)
+
+	return &Feedback{
+		Type:    Error,
+		Emoji:   "❌",
+		Message: message,
+	}
+}
+
 // NewHelp creates help feedback with usage instructions
 func NewHelp() *Feedback {
 	message := "ℹ️ **Smyklot Bot - Help**\n\n" +

--- a/pkg/feedback/feedback.go
+++ b/pkg/feedback/feedback.go
@@ -513,7 +513,15 @@ func NewHelp() *Feedback {
 		"- `/approve` or `@smyklot approve` or `approve` - Approve the PR\n" +
 		"- `accept` or `lgtm` - Alternative ways to approve\n\n" +
 		"**Merge Commands:**\n" +
-		"- `/merge` or `@smyklot merge` or `merge` - Merge the PR\n\n" +
+		"- `/merge` or `@smyklot merge` or `merge` - Merge the PR\n" +
+		"- `/squash` - Squash and merge the PR\n" +
+		"- `/rebase` - Rebase and merge the PR\n\n" +
+		"**Merge After CI:**\n" +
+		"Add `after CI` to defer merge until checks pass:\n" +
+		"- `/merge after CI` - Merge after CI passes\n" +
+		"- `/squash when green` - Squash after checks are green\n" +
+		"- `/rebase once CI passes` - Rebase after CI passes\n" +
+		"The bot will add ⏳ reaction and merge automatically when CI succeeds.\n\n" +
 		"**Review Management:**\n" +
 		"- `/unapprove` or `@smyklot unapprove` or `unapprove` - Dismiss your approval\n" +
 		"- `disapprove` - Alternative way to unapprove\n\n" +

--- a/pkg/feedback/types.go
+++ b/pkg/feedback/types.go
@@ -15,6 +15,10 @@ const (
 	// Warning represents a non-critical issue
 	// Response: Emoji reaction (⚠️) + informative comment
 	Warning Type = "warning"
+
+	// Pending represents an operation waiting for external condition
+	// Response: Emoji reaction (⏳) + informative comment
+	Pending Type = "pending"
 )
 
 // Feedback represents a response to a command

--- a/pkg/github/types.go
+++ b/pkg/github/types.go
@@ -109,3 +109,30 @@ const (
 	// MergeMethodRebase rebases and merges
 	MergeMethodRebase MergeMethod = "rebase"
 )
+
+// CheckStatus represents the status of CI checks on a commit
+type CheckStatus struct {
+	// AllPassing indicates all checks have completed successfully
+	AllPassing bool
+
+	// Pending indicates at least one check is still running
+	Pending bool
+
+	// Failing indicates at least one check has failed
+	Failing bool
+
+	// Summary provides a human-readable status (e.g., "5/6 checks passing")
+	Summary string
+
+	// Total is the total number of check runs
+	Total int
+
+	// Passed is the number of successful check runs
+	Passed int
+
+	// Failed is the number of failed check runs
+	Failed int
+
+	// InProgress is the number of check runs still running
+	InProgress int
+}

--- a/pkg/github/types.go
+++ b/pkg/github/types.go
@@ -74,6 +74,9 @@ const (
 
 	// ReactionCleanup represents cleanup command (❤️)
 	ReactionCleanup ReactionType = "heart"
+
+	// ReactionPendingCI represents waiting for CI (⏳)
+	ReactionPendingCI ReactionType = "hourglass"
 )
 
 // Reaction represents a reaction on a comment
@@ -94,6 +97,15 @@ const (
 
 	// LabelReactionCleanup indicates cleanup was triggered via ❤️ reaction
 	LabelReactionCleanup = "smyklot:reaction-cleanup"
+
+	// LabelPendingCIMerge indicates PR is waiting for CI before merge
+	LabelPendingCIMerge = "smyklot:pending-ci"
+
+	// LabelPendingCISquash indicates PR is waiting for CI before squash merge
+	LabelPendingCISquash = "smyklot:pending-ci:squash"
+
+	// LabelPendingCIRebase indicates PR is waiting for CI before rebase merge
+	LabelPendingCIRebase = "smyklot:pending-ci:rebase"
 )
 
 // MergeMethod represents the type of merge method to use


### PR DESCRIPTION
## Motivation

Users want to approve PRs immediately but defer merge until CI passes. Currently, if CI is failing, the merge command either fails or requires GitHub's auto-merge feature which may not be available on all repositories.

## Implementation information

- Add `WaitForCI` field to `Command` struct with modifier detection regex matching patterns like `after CI`, `when green`, `once checks pass`
- Add `GetCheckStatus` GitHub client method for querying commit check run status via REST API
- Add ⏳ hourglass reaction (`ReactionPendingCI`) and `smyklot:pending-ci:{method}` labels to track pending merges
- Add `NewPendingCI`, `NewPendingCIMerged`, `NewPendingCIFailed` feedback types
- Extend `processPendingCIPRs` in poll workflow to check CI status and auto-merge when successful
- Update help message documenting the new feature