### PR TITLE
ci(workflows): align with klaudiush configuration

### DIFF
--- a/.github/workflows/poll-reactions.yaml
+++ b/.github/workflows/poll-reactions.yaml
@@ -1,28 +1,41 @@
+# Poll Reactions workflow for smyklot
+# Polls PR reactions via smyklot bot for auto-merge
+
 name: Poll Reactions
 
 on:
   schedule:
     # Run every 5 minutes
     - cron: '*/5 * * * *'
-  workflow_dispatch: # Allow manual triggering
+  workflow_dispatch:
 
 permissions:
   contents: read
   pull-requests: write
   issues: write
-  members: read  # Required for team membership validation
 
 jobs:
   poll-reactions:
     name: Poll PR Reactions
     runs-on: ubuntu-24.04
+
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      - name: Poll and process reactions
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94 # v2.2.0
+        with:
+          app-id: ${{ vars.SMYKLOT_APP_ID }}
+          private-key: ${{ secrets.SMYKLOT_PRIVATE_KEY }}
+
+      - name: Poll reactions on open PRs
         uses: ./
+        with:
+          args: poll
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
+          SMYKLOT_CONFIG: ${{ vars.SMYKLOT_CONFIG }}

--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -1,3 +1,6 @@
+# PR Commands workflow for smyklot
+# Handles PR commands via smyklot bot
+
 name: PR Commands
 
 on:
@@ -8,21 +11,28 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
-  members: read  # Required for team membership validation
 
 jobs:
   handle-command:
     name: Handle PR Command
-    if: github.event.issue.pull_request
+    if: github.event.issue.pull_request && github.event.comment.user.type != 'Bot'
     runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: Execute command
+    steps:
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94 # v2.2.0
+        with:
+          app-id: ${{ vars.SMYKLOT_APP_ID }}
+          private-key: ${{ secrets.SMYKLOT_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Run Smyklot
         uses: ./
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           COMMENT_BODY: ${{ github.event.comment.body }}
           COMMENT_ID: ${{ github.event.comment.id }}
           COMMENT_ACTION: ${{ github.event.action }}
@@ -30,3 +40,4 @@ jobs:
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
           COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          SMYKLOT_CONFIG: ${{ vars.SMYKLOT_CONFIG }}


### PR DESCRIPTION
## Motivation

The workflows were broken due to invalid `members: read` permission. Additionally, the workflows were missing several features that klaudiush has for better bot operation.

## Implementation information

- Use GitHub App token instead of `secrets.GITHUB_TOKEN` for elevated permissions
- Add bot comment filtering (`github.event.comment.user.type != 'Bot'`) to prevent infinite loops
- Update `actions/checkout` from v5.0.0 to v6.0.1
- Add `SMYKLOT_CONFIG` environment variable support
- Remove invalid `members: read` permission that was causing workflow validation errors