### PR TITLE
feat(commands): add CI terms and required checks

### DIFF
--- a/cmd/github-action/main_test.go
+++ b/cmd/github-action/main_test.go
@@ -9,24 +9,48 @@ import (
 
 var _ = Describe("Main Pending CI Functions [Unit]", func() {
 	Describe("getPendingCILabel", func() {
-		It("should return merge label for merge method", func() {
-			label := getPendingCILabel(github.MergeMethodMerge)
-			Expect(label).To(Equal(github.LabelPendingCIMerge))
+		Context("with requiredOnly=false", func() {
+			It("should return merge label for merge method", func() {
+				label := getPendingCILabel(github.MergeMethodMerge, false)
+				Expect(label).To(Equal(github.LabelPendingCIMerge))
+			})
+
+			It("should return squash label for squash method", func() {
+				label := getPendingCILabel(github.MergeMethodSquash, false)
+				Expect(label).To(Equal(github.LabelPendingCISquash))
+			})
+
+			It("should return rebase label for rebase method", func() {
+				label := getPendingCILabel(github.MergeMethodRebase, false)
+				Expect(label).To(Equal(github.LabelPendingCIRebase))
+			})
+
+			It("should return merge label for unknown method", func() {
+				label := getPendingCILabel(github.MergeMethod("unknown"), false)
+				Expect(label).To(Equal(github.LabelPendingCIMerge))
+			})
 		})
 
-		It("should return squash label for squash method", func() {
-			label := getPendingCILabel(github.MergeMethodSquash)
-			Expect(label).To(Equal(github.LabelPendingCISquash))
-		})
+		Context("with requiredOnly=true", func() {
+			It("should return required merge label for merge method", func() {
+				label := getPendingCILabel(github.MergeMethodMerge, true)
+				Expect(label).To(Equal(github.LabelPendingCIMergeRequired))
+			})
 
-		It("should return rebase label for rebase method", func() {
-			label := getPendingCILabel(github.MergeMethodRebase)
-			Expect(label).To(Equal(github.LabelPendingCIRebase))
-		})
+			It("should return required squash label for squash method", func() {
+				label := getPendingCILabel(github.MergeMethodSquash, true)
+				Expect(label).To(Equal(github.LabelPendingCISquashRequired))
+			})
 
-		It("should return merge label for unknown method", func() {
-			label := getPendingCILabel(github.MergeMethod("unknown"))
-			Expect(label).To(Equal(github.LabelPendingCIMerge))
+			It("should return required rebase label for rebase method", func() {
+				label := getPendingCILabel(github.MergeMethodRebase, true)
+				Expect(label).To(Equal(github.LabelPendingCIRebaseRequired))
+			})
+
+			It("should return required merge label for unknown method", func() {
+				label := getPendingCILabel(github.MergeMethod("unknown"), true)
+				Expect(label).To(Equal(github.LabelPendingCIMergeRequired))
+			})
 		})
 	})
 

--- a/cmd/github-action/poll_test.go
+++ b/cmd/github-action/poll_test.go
@@ -16,32 +16,58 @@ import (
 var _ = Describe("Poll Pending CI [Unit]", func() {
 	Describe("parsePendingCILabel", func() {
 		It("should parse smyklot:pending-ci label as merge method", func() {
-			method, label := parsePendingCILabel(github.LabelPendingCIMerge)
+			method, requiredOnly, label := parsePendingCILabel(github.LabelPendingCIMerge)
 			Expect(method).To(Equal(github.MergeMethodMerge))
+			Expect(requiredOnly).To(BeFalse())
 			Expect(label).To(Equal(github.LabelPendingCIMerge))
 		})
 
 		It("should parse smyklot:pending-ci:squash label as squash method", func() {
-			method, label := parsePendingCILabel(github.LabelPendingCISquash)
+			method, requiredOnly, label := parsePendingCILabel(github.LabelPendingCISquash)
 			Expect(method).To(Equal(github.MergeMethodSquash))
+			Expect(requiredOnly).To(BeFalse())
 			Expect(label).To(Equal(github.LabelPendingCISquash))
 		})
 
 		It("should parse smyklot:pending-ci:rebase label as rebase method", func() {
-			method, label := parsePendingCILabel(github.LabelPendingCIRebase)
+			method, requiredOnly, label := parsePendingCILabel(github.LabelPendingCIRebase)
 			Expect(method).To(Equal(github.MergeMethodRebase))
+			Expect(requiredOnly).To(BeFalse())
 			Expect(label).To(Equal(github.LabelPendingCIRebase))
 		})
 
+		It("should parse smyklot:pending-ci:required label as required merge method", func() {
+			method, requiredOnly, label := parsePendingCILabel(github.LabelPendingCIMergeRequired)
+			Expect(method).To(Equal(github.MergeMethodMerge))
+			Expect(requiredOnly).To(BeTrue())
+			Expect(label).To(Equal(github.LabelPendingCIMergeRequired))
+		})
+
+		It("should parse smyklot:pending-ci:squash:required label as required squash method", func() {
+			method, requiredOnly, label := parsePendingCILabel(github.LabelPendingCISquashRequired)
+			Expect(method).To(Equal(github.MergeMethodSquash))
+			Expect(requiredOnly).To(BeTrue())
+			Expect(label).To(Equal(github.LabelPendingCISquashRequired))
+		})
+
+		It("should parse smyklot:pending-ci:rebase:required label as required rebase method", func() {
+			method, requiredOnly, label := parsePendingCILabel(github.LabelPendingCIRebaseRequired)
+			Expect(method).To(Equal(github.MergeMethodRebase))
+			Expect(requiredOnly).To(BeTrue())
+			Expect(label).To(Equal(github.LabelPendingCIRebaseRequired))
+		})
+
 		It("should return empty string for non-pending-ci labels", func() {
-			method, label := parsePendingCILabel("some-other-label")
+			method, requiredOnly, label := parsePendingCILabel("some-other-label")
 			Expect(method).To(Equal(github.MergeMethod("")))
+			Expect(requiredOnly).To(BeFalse())
 			Expect(label).To(BeEmpty())
 		})
 
 		It("should return empty string for reaction labels", func() {
-			method, label := parsePendingCILabel(github.LabelReactionApprove)
+			method, requiredOnly, label := parsePendingCILabel(github.LabelReactionApprove)
 			Expect(method).To(Equal(github.MergeMethod("")))
+			Expect(requiredOnly).To(BeFalse())
 			Expect(label).To(BeEmpty())
 		})
 	})

--- a/pkg/commands/types.go
+++ b/pkg/commands/types.go
@@ -51,4 +51,8 @@ type Command struct {
 	// WaitForCI indicates merge should be deferred until CI passes
 	// Set when "after CI", "when green", "when checks pass" modifier is detected
 	WaitForCI bool
+
+	// RequiredChecksOnly indicates only required checks should be considered
+	// Set when "required" modifier is detected (e.g., "after required CI")
+	RequiredChecksOnly bool
 }

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -502,7 +502,7 @@ var _ = Describe("GitHub Client [Unit]", func() {
 				client, err := github.NewClient("test-token", server.URL)
 				Expect(err).NotTo(HaveOccurred())
 
-				status, err := client.GetCheckStatus(context.Background(), "owner", "repo", "abc123")
+				status, err := client.GetCheckStatus(context.Background(), "owner", "repo", "abc123", nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(status).NotTo(BeNil())
 				Expect(status.AllPassing).To(BeTrue())
@@ -532,7 +532,7 @@ var _ = Describe("GitHub Client [Unit]", func() {
 				client, err := github.NewClient("test-token", server.URL)
 				Expect(err).NotTo(HaveOccurred())
 
-				status, err := client.GetCheckStatus(context.Background(), "owner", "repo", "abc123")
+				status, err := client.GetCheckStatus(context.Background(), "owner", "repo", "abc123", nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(status.AllPassing).To(BeFalse())
 				Expect(status.Pending).To(BeTrue())
@@ -560,7 +560,7 @@ var _ = Describe("GitHub Client [Unit]", func() {
 				client, err := github.NewClient("test-token", server.URL)
 				Expect(err).NotTo(HaveOccurred())
 
-				status, err := client.GetCheckStatus(context.Background(), "owner", "repo", "abc123")
+				status, err := client.GetCheckStatus(context.Background(), "owner", "repo", "abc123", nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(status.AllPassing).To(BeFalse())
 				Expect(status.Pending).To(BeFalse())
@@ -584,7 +584,7 @@ var _ = Describe("GitHub Client [Unit]", func() {
 				client, err := github.NewClient("test-token", server.URL)
 				Expect(err).NotTo(HaveOccurred())
 
-				status, err := client.GetCheckStatus(context.Background(), "owner", "repo", "abc123")
+				status, err := client.GetCheckStatus(context.Background(), "owner", "repo", "abc123", nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(status.AllPassing).To(BeFalse())
 				Expect(status.Pending).To(BeFalse())
@@ -603,7 +603,7 @@ var _ = Describe("GitHub Client [Unit]", func() {
 				client, err := github.NewClient("test-token", server.URL)
 				Expect(err).NotTo(HaveOccurred())
 
-				_, err = client.GetCheckStatus(context.Background(), "owner", "repo", "invalid-ref")
+				_, err = client.GetCheckStatus(context.Background(), "owner", "repo", "invalid-ref", nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("404"))
 			})
@@ -629,7 +629,7 @@ var _ = Describe("GitHub Client [Unit]", func() {
 				client, err := github.NewClient("test-token", server.URL)
 				Expect(err).NotTo(HaveOccurred())
 
-				status, err := client.GetCheckStatus(context.Background(), "owner", "repo", "abc123")
+				status, err := client.GetCheckStatus(context.Background(), "owner", "repo", "abc123", nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(status.Passed).To(Equal(3))
 				Expect(status.Failed).To(Equal(4))
@@ -654,7 +654,7 @@ var _ = Describe("GitHub Client [Unit]", func() {
 				client, err := github.NewClient("test-token", server.URL)
 				Expect(err).NotTo(HaveOccurred())
 
-				status, err := client.GetCheckStatus(context.Background(), "owner", "repo", "abc123")
+				status, err := client.GetCheckStatus(context.Background(), "owner", "repo", "abc123", nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(status.InProgress).To(Equal(4))
 				Expect(status.Passed).To(Equal(1))

--- a/pkg/github/types.go
+++ b/pkg/github/types.go
@@ -106,6 +106,15 @@ const (
 
 	// LabelPendingCIRebase indicates PR is waiting for CI before rebase merge
 	LabelPendingCIRebase = "smyklot:pending-ci:rebase"
+
+	// LabelPendingCIMergeRequired indicates PR is waiting for required CI only before merge
+	LabelPendingCIMergeRequired = "smyklot:pending-ci:required"
+
+	// LabelPendingCISquashRequired indicates PR is waiting for required CI only before squash merge
+	LabelPendingCISquashRequired = "smyklot:pending-ci:squash:required"
+
+	// LabelPendingCIRebaseRequired indicates PR is waiting for required CI only before rebase merge
+	LabelPendingCIRebaseRequired = "smyklot:pending-ci:rebase:required"
 )
 
 // MergeMethod represents the type of merge method to use


### PR DESCRIPTION
## Summary

Enable bare commands with CI modifiers and add support for waiting only on required status checks when merging PRs.

## Motivation

Current limitation: bare commands like `squash after CI` fail natural language detection because "after" is a natural language word, forcing users to use slash commands (`/squash after CI`) or mentions (`@smyklot squash after CI`).

Current gap: no way to wait only for required checks. Users must wait for all checks including optional ones, even when only required checks matter for branch protection.

This PR enables:

- Natural bare commands with CI context
- Filtering to only required status checks
- More intuitive command syntax

## Implementation information

### Extended CI Terminology Recognition

Update parser to recognize CI-related terms as technical context:

- CI/CD terms: CI, CD, GHA, workflows, GitHub Actions
- Temporal words: after, when, once (in CI context)
- Completion states: pass, finish, complete
- All counted toward command-heavy threshold (>66%)

Changes in `pkg/commands/parser.go`:

- Add `ciRelatedWords` map to `isCommandHeavyLine()`
- Add `ciRelatedWords` map to `isLineOnlyCommandsAndFillers()`
- Update regex patterns to match extended terminology

### Required Checks Only Mode

Add support for "required" modifier to filter checks:

- New field `RequiredChecksOnly` in Command struct
- New regex `requiredChecksRegex` to detect modifier
- New function `detectRequiredChecksModifier()`

Changes in `pkg/github/client.go`:

- Add `GetRequiredStatusChecks()` method
- Update `GetCheckStatus()` signature to accept `requiredOnly []string`
- Filter check runs by required checks list

Changes in `pkg/github/types.go`:

- Add labels: `LabelPendingCIMergeRequired`, `LabelPendingCISquashRequired`, `LabelPendingCIRebaseRequired`

Changes in `cmd/github-action/main.go`:

- Pass `RequiredChecksOnly` through `executeMerge()`
- Update `executePendingCIMerge()` to fetch and filter required checks
- Update `getPendingCILabel()` to return required-variant labels

Changes in `cmd/github-action/poll.go`:

- Add `requiredOnly` field to `pendingCIPR` struct
- Update `parsePendingCILabel()` to return `requiredOnly` flag
- Fetch required checks in `processPendingCIPR()` when needed

### Testing

Added 40+ comprehensive tests:

- Extended CI terminology parsing
- Required modifier detection
- Bare command recognition with CI context
- Label generation for all combinations
- Poll workflow integration

All 162 command parser tests passing.

## Supporting documentation

Examples of new commands:

**All checks mode:**

- `squash after CI`
- `merge when workflows finish`
- `rebase once GHA completes`

**Required checks only:**

- `squash after required CI`
- `merge when required workflows pass`
- `rebase after required GHA`