### PR TITLE
fix(github): use valid reaction for pending CI

### DIFF
--- a/pkg/github/types.go
+++ b/pkg/github/types.go
@@ -75,8 +75,8 @@ const (
 	// ReactionCleanup represents cleanup command (❤️)
 	ReactionCleanup ReactionType = "heart"
 
-	// ReactionPendingCI represents waiting for CI (⏳)
-	ReactionPendingCI ReactionType = "hourglass"
+	// ReactionPendingCI represents waiting for CI (👀)
+	ReactionPendingCI ReactionType = "eyes"
 )
 
 // Reaction represents a reaction on a comment


### PR DESCRIPTION
## Motivation

The "merge after CI" feature fails with a 422 error because `ReactionPendingCI` uses "hourglass" which is not a valid GitHub reaction.

See: https://github.com/smykla-labs/klaudiush/actions/runs/19925409264/job/57123855165

## Implementation information

- Changed `ReactionPendingCI` from "hourglass" to "eyes"
- GitHub only supports: +1, -1, laugh, confused, heart, hooray, rocket, eyes
- The "eyes" reaction is semantically appropriate (watching/waiting for CI)