### PR TITLE
ci(release): notify org of new release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -147,3 +147,32 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Notify organization repositories of new release
+  notify-org:
+    name: Notify Org
+    runs-on: ubuntu-24.04
+    needs: [release, goreleaser]
+    if: needs.goreleaser.result == 'success'
+    permissions:
+      contents: read
+
+    steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94 # v2.2.0
+        with:
+          app-id: ${{ vars.SMYKLOT_APP_ID }}
+          private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}
+          owner: smykla-labs
+          repositories: .github
+
+      - name: Trigger smyklot sync
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ needs.release.outputs.new_release_version }}
+          TAG: ${{ needs.release.outputs.new_release_git_tag }}
+        run: |
+          gh api repos/smykla-labs/.github/dispatches \
+            -f event_type="smyklot-release" \
+            -f "client_payload=$(jq -n --arg version "$VERSION" --arg tag "$TAG" '{version: $version, tag: $tag}')"


### PR DESCRIPTION
## Motivation

When smyklot releases a new version, organization repositories need their smyklot version references updated. This PR adds automated notification to trigger the sync workflow in the `.github` repository.

## Implementation information

**New job** (`notify-org`):

- Runs after successful goreleaser job
- Generates GitHub App token for `.github` repository access
- Dispatches `repository_dispatch` event with version information
- Uses `jq` for safe JSON payload construction (prevents injection attacks)

**Event payload**:

```json
{
  "version": "1.2.3",
  "tag": "v1.2.3"
}
```

This triggers the `sync-smyklot.yml` workflow in the `.github` repo, which updates smyklot references across all organization repositories.

## Supporting documentation

Part of smyklot version sync automation. See companion PR: smykla-labs/.github#5