### PR TITLE
feat(config): add renovate.json sync configuration

### DIFF
--- a/.github/sync-config.yml
+++ b/.github/sync-config.yml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/smykla-labs/.github/main/schemas/sync-config.schema.json
+---
+# Unified Sync Configuration
+# Enable label removal to keep labels in sync with central config
+
+sync:
+  labels:
+    allow_removal: true
+  files:
+    merge:
+      - path: renovate.json
+        strategy: deep-merge
+        overrides:
+          rebaseWhen: conflicted


### PR DESCRIPTION
## Motivation

Enable automatic synchronization of Renovate configuration from org defaults while preserving smyklot-specific customizations. This ensures the project stays up-to-date with org-level security and dependency management policies without manual maintenance.

## Implementation information

- Added `.github/sync-config.yml` with deep-merge strategy for `renovate.json`
- Configured override to preserve `rebaseWhen: conflicted` setting
- Enabled label removal to keep labels synchronized with central config
- Added JSON schema reference for validation

The deep-merge strategy will automatically inherit org settings for `osvVulnerabilityAlerts`, `packageRules`, `vulnerabilityAlerts`, and `ignorePaths` while keeping smyklot's minimal preset configuration intact.