### PR TITLE
fix(docker): avoid QEMU emulation failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:1@sha256:b6afd42430b15f2d2a4c5a02b919e98a525b785b1aaff16747d2f623364e39b6
 
-FROM alpine:latest@sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375 AS certs
+# Use BUILDPLATFORM to run apk on native arch (avoids QEMU emulation issues)
+# CA certificates are architecture-independent, so this is safe
+FROM --platform=$BUILDPLATFORM alpine:3.21@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c AS certs
 RUN apk --no-cache add ca-certificates
 
 FROM scratch


### PR DESCRIPTION
## Motivation

Docker image publishing has been failing since v1.10.0 due to QEMU emulation issues when building arm64 images on amd64 runners. Alpine's apk triggers fail under QEMU with error 127. Images only exist up to v1.9.2.

## Implementation information

- Use `--platform=$BUILDPLATFORM` for the certs stage to run `apk add` on the native architecture (avoids QEMU emulation)
- CA certificates are architecture-independent, so copying them across platforms is safe
- Pin Alpine to 3.21 with digest for reproducibility

<!-- > Changelog: skip -->