### PR TITLE
fix(release): fix client_payload JSON in gh api

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -175,4 +175,4 @@ jobs:
         run: |
           gh api repos/smykla-labs/.github/dispatches \
             -f event_type="smyklot-release" \
-            -f "client_payload=$(jq -n --arg version "$VERSION" --arg tag "$TAG" '{version: $version, tag: $tag}')"
+            -F client_payload="$(jq -nc --arg version "$VERSION" --arg tag "$TAG" '{version: $version, tag: $tag}')"


### PR DESCRIPTION
## Motivation

The notify-org job fails because `client_payload` is passed as a string instead of JSON object:

```
For 'properties/client_payload', "..." is not an object.
```

## Implementation information

- Use `-F` instead of `-f` to pass `client_payload` as JSON object
- Use `jq -c` for compact output (single line)