### PR TITLE
feat(config): add `quiet_pending` option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -436,6 +436,7 @@ All configuration options support three input methods with precedence:
 {
   "quiet_success": false,
   "quiet_reactions": false,
+  "quiet_pending": false,
   "allowed_commands": [],
   "command_aliases": {},
   "command_prefix": "/",
@@ -454,6 +455,7 @@ All variables prefixed with `SMYKLOT_`:
 
 - `SMYKLOT_QUIET_SUCCESS`
 - `SMYKLOT_QUIET_REACTIONS`
+- `SMYKLOT_QUIET_PENDING`
 - `SMYKLOT_ALLOWED_COMMANDS`
 - `SMYKLOT_COMMAND_ALIASES`
 - `SMYKLOT_COMMAND_PREFIX`

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Set a `SMYKLOT_CONFIG` repository variable with your complete configuration:
 {
   "quiet_success": false,
   "quiet_reactions": false,
+  "quiet_pending": false,
   "allowed_commands": ["approve", "merge"],
   "command_aliases": {
     "ok": "approve",
@@ -214,6 +215,7 @@ Configure individual settings via repository variables or environment variables 
 |------------------------------------|---------|----------------|----------------------------------------------------------------------------|
 | `SMYKLOT_QUIET_SUCCESS`            | boolean | `false`        | Disable success feedback comments                                          |
 | `SMYKLOT_QUIET_REACTIONS`          | boolean | `false`        | Disable reaction-based approval/merge comments                             |
+| `SMYKLOT_QUIET_PENDING`            | boolean | `false`        | Disable pending CI comments (reactions only for "merge after CI")          |
 | `SMYKLOT_ALLOWED_COMMANDS`         | list    | all            | Limit which commands are allowed                                           |
 | `SMYKLOT_COMMAND_ALIASES`          | map     | default        | Define custom command aliases                                              |
 | `SMYKLOT_COMMAND_PREFIX`           | string  | `/`            | Custom command prefix                                                      |

--- a/cmd/github-action/main.go
+++ b/cmd/github-action/main.go
@@ -954,7 +954,7 @@ func executePendingCIMerge(
 	// Return pending feedback
 	methodName := getMergeMethodName(method)
 
-	return feedback.NewPendingCI(rc.CommentAuthor, methodName), nil
+	return feedback.NewPendingCI(rc.CommentAuthor, methodName, bc.QuietPending), nil
 }
 
 // executeImmediateMerge performs the actual merge when CI has already passed

--- a/cmd/github-action/poll_test.go
+++ b/cmd/github-action/poll_test.go
@@ -296,7 +296,7 @@ var _ = Describe("Poll Pending CI [Unit]", func() {
 					label:  github.LabelPendingCIMerge,
 				}
 
-				err = processPendingCIPR(context.Background(), client, bc, "owner", "repo", pr)
+				err = processPendingCIPR(context.Background(), client, bc, "owner", "repo", pr, "smyklot[bot]")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(mergeRequested).To(BeTrue())
 				Expect(labelRemoved).To(BeTrue())
@@ -359,7 +359,7 @@ var _ = Describe("Poll Pending CI [Unit]", func() {
 					label:  github.LabelPendingCIMerge,
 				}
 
-				err = processPendingCIPR(context.Background(), client, bc, "owner", "repo", pr)
+				err = processPendingCIPR(context.Background(), client, bc, "owner", "repo", pr, "smyklot[bot]")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(labelRemoved).To(BeTrue())
 				Expect(commentPosted).To(BeTrue())
@@ -415,7 +415,7 @@ var _ = Describe("Poll Pending CI [Unit]", func() {
 					label:  github.LabelPendingCIMerge,
 				}
 
-				err = processPendingCIPR(context.Background(), client, bc, "owner", "repo", pr)
+				err = processPendingCIPR(context.Background(), client, bc, "owner", "repo", pr, "smyklot[bot]")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(mergeRequested).To(BeFalse())
 				Expect(labelRemoved).To(BeFalse())
@@ -478,7 +478,7 @@ var _ = Describe("Poll Pending CI [Unit]", func() {
 					label:  github.LabelPendingCISquash,
 				}
 
-				err = processPendingCIPR(context.Background(), client, bc, "owner", "repo", pr)
+				err = processPendingCIPR(context.Background(), client, bc, "owner", "repo", pr, "smyklot[bot]")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(mergeMethod).To(Equal("squash"))
 			})
@@ -508,7 +508,7 @@ var _ = Describe("Poll Pending CI [Unit]", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			bc := config.Default()
-			err = processPendingCIPRs(context.Background(), client, bc, "owner", "repo", prs)
+			err = processPendingCIPRs(context.Background(), client, bc, "owner", "repo", prs, "smyklot[bot]")
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,6 +18,9 @@ const (
 	// KeyQuietReactions is the config key for quiet_reactions setting
 	KeyQuietReactions = "quiet_reactions"
 
+	// KeyQuietPending is the config key for quiet_pending setting
+	KeyQuietPending = "quiet_pending"
+
 	// KeyAllowedCommands is the config key for allowed_commands setting
 	KeyAllowedCommands = "allowed_commands"
 
@@ -57,6 +60,7 @@ func SetupViper(v *viper.Viper) {
 	// Set defaults
 	v.SetDefault(KeyQuietSuccess, false)
 	v.SetDefault(KeyQuietReactions, false)
+	v.SetDefault(KeyQuietPending, false)
 	v.SetDefault(KeyAllowedCommands, []string{})
 	v.SetDefault(KeyCommandAliases, map[string]string{})
 	v.SetDefault(KeyCommandPrefix, DefaultCommandPrefix)
@@ -77,6 +81,7 @@ func LoadFromViper(v *viper.Viper) *Config {
 	return &Config{
 		QuietSuccess:           v.GetBool(KeyQuietSuccess),
 		QuietReactions:         v.GetBool(KeyQuietReactions),
+		QuietPending:           v.GetBool(KeyQuietPending),
 		AllowedCommands:        v.GetStringSlice(KeyAllowedCommands),
 		CommandAliases:         v.GetStringMapString(KeyCommandAliases),
 		CommandPrefix:          v.GetString(KeyCommandPrefix),

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -13,6 +13,9 @@ type Config struct {
 	// QuietReactions disables reaction-based approval/merge comments
 	QuietReactions bool `json:"quiet_reactions"`
 
+	// QuietPending disables pending CI comments (keeps reactions only)
+	QuietPending bool `json:"quiet_pending"`
+
 	// AllowedCommands is a list of allowed command names
 	// an Empty list means all commands are allowed
 	AllowedCommands []string `json:"allowed_commands"`
@@ -50,6 +53,7 @@ func Default() *Config {
 	return &Config{
 		QuietSuccess:           false,
 		QuietReactions:         false,
+		QuietPending:           false,
 		AllowedCommands:        []string{},
 		CommandAliases:         make(map[string]string),
 		CommandPrefix:          DefaultCommandPrefix,

--- a/pkg/feedback/feedback.go
+++ b/pkg/feedback/feedback.go
@@ -448,14 +448,19 @@ func NewReactionMergeRemoved() *Feedback {
 // NewPendingCI creates pending feedback for when merge is waiting for CI
 //
 // The message indicates who triggered the merge and what merge method will be used
-func NewPendingCI(author string, method string) *Feedback {
-	message := fmt.Sprintf(
-		"⏳ **Waiting for CI**\n\n"+
-			"Merge requested by `%s`. Will %s when all checks pass.\n\n"+
-			"The PR will be merged automatically once CI succeeds.",
-		author,
-		method,
-	)
+// If quietPending is true, only an emoji reaction is used (no comment)
+func NewPendingCI(author string, method string, quietPending bool) *Feedback {
+	message := ""
+
+	if !quietPending {
+		message = fmt.Sprintf(
+			"⏳ **Waiting for CI**\n\n"+
+				"Merge requested by `%s`. Will %s when all checks pass.\n\n"+
+				"The PR will be merged automatically once CI succeeds.",
+			author,
+			method,
+		)
+	}
 
 	return &Feedback{
 		Type:    Pending,

--- a/pkg/feedback/feedback_test.go
+++ b/pkg/feedback/feedback_test.go
@@ -327,7 +327,7 @@ var _ = Describe("Feedback System [Unit]", func() {
 
 	Describe("NewPendingCI", func() {
 		It("should create pending feedback with hourglass emoji", func() {
-			fb := feedback.NewPendingCI("alice", "merge")
+			fb := feedback.NewPendingCI("alice", "merge", false)
 			Expect(fb.Type).To(Equal(feedback.Pending))
 			Expect(fb.Emoji).To(Equal("⏳"))
 			Expect(fb.Message).To(ContainSubstring("Waiting for CI"))
@@ -339,14 +339,21 @@ var _ = Describe("Feedback System [Unit]", func() {
 			methods := []string{"merge", "squash", "rebase"}
 
 			for _, method := range methods {
-				fb := feedback.NewPendingCI("bob", method)
+				fb := feedback.NewPendingCI("bob", method, false)
 				Expect(fb.Message).To(ContainSubstring(method))
 			}
 		})
 
 		It("should indicate automatic merge on CI success", func() {
-			fb := feedback.NewPendingCI("alice", "merge")
+			fb := feedback.NewPendingCI("alice", "merge", false)
 			Expect(fb.Message).To(ContainSubstring("automatically"))
+		})
+
+		It("should create pending feedback with emoji only when quietPending=true", func() {
+			fb := feedback.NewPendingCI("alice", "merge", true)
+			Expect(fb.Type).To(Equal(feedback.Pending))
+			Expect(fb.Emoji).To(Equal("⏳"))
+			Expect(fb.Message).To(BeEmpty())
 		})
 	})
 


### PR DESCRIPTION
# Summary

- Add `quiet_pending` configuration option to silence "Waiting for CI" comments
- Automatically update 👀 reaction to 👍 when merge completes after CI passes

## Motivation

When using "merge after CI" commands (`/merge after CI`, `/squash when green`), the bot currently posts a "Waiting for CI" comment that can be noisy. Users requested a way to silence this comment while keeping the reaction-only feedback.

Additionally, the 👀 reaction was left unchanged after successful merge, making it unclear whether the operation completed. Replacing it with 👍 provides clear visual feedback.

## Implementation information

- Add `quiet_pending` config option to `pkg/config` (types, config.go)
- Update `NewPendingCI()` in `pkg/feedback/feedback.go` to accept `quietPending` parameter
- Add `UpdatePendingCIReaction()` to `pkg/github/client.go` to find and update bot reactions
- Add `RemoveReactionByUser()` helper for user-specific reaction removal
- Pass `botUsername` through poll.go call chain for reaction updates
- Update tests and documentation